### PR TITLE
(issue-#24) removing defer

### DIFF
--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -86,12 +86,12 @@ func (r *Remote) doAction(action string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
 		return fmt.Errorf("Bad status: %d %s", resp.StatusCode, resp.Status)
 	}
-
+	resp.Body.Close()
 	return nil
 }
 
@@ -149,13 +149,15 @@ func (r *Remote) info() (rest.Replica, error) {
 	if err != nil {
 		return replica, err
 	}
-	defer resp.Body.Close()
+
 
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
 		return replica, fmt.Errorf("Bad status: %d %s", resp.StatusCode, resp.Status)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&replica)
+	resp.Body.Close()
 	return replica, err
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -26,10 +26,9 @@ func NewServer(conn net.Conn, data types.DataProcessor) *Server {
 
 func (s *Server) Handle() error {
 	go s.write()
-	defer func() {
-		s.done <- struct{}{}
-	}()
-	return s.read()
+	err:= s.read()
+	s.done <- struct{}{}
+	return err
 }
 
 func (s *Server) readFromWire(ret chan<- error) {


### PR DESCRIPTION
Signed-off-by: khushbuparakh <khushbuparakh@hotmail.com>
I started from ReadAt, WriteAt functions.
So func (s *Server) had a defer code. 
I modified it to return err
Then used at the very low level I/O code and 
follow the path to know IO path in controller side, and,
similarly Handle() in rpc/server.go for replica side IO handling.
