### PR TITLE
Minor Readme Edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Longhorn Engine
 
 Longhorn Engine implements a lightweight block device storage controller capable of storing the data in a number of replicas. It functions like a network RAID controller.
 
--The replicas are backed by Linux sparse files, and support efficient snapshots using differencing disks.
--The replicas function like a networked disk, supporting read/write operations over a network protocol.
--The frontend (either TCMU or Open-iSCSI/tgt are supported at this moment) is a kernel driver that translates read/write operations on the Longhorn block device (mapped at `/dev/longhorn/vol-name`) to user-level network requests on the controller.
--Each Longhorn block device is backed by its own dedicated controller.
--The controller sychronously replicates write operations to all replicas.
--The controller detects faulty replicas and rebuilds replicas.
--The controller coordinates snapshot and backup operations.
--Controllers and replicas are packaged as Docker containers.
+ - The replicas are backed by Linux sparse files, and support efficient snapshots using differencing disks.
+ - The replicas function like a networked disk, supporting read/write operations over a network protocol.
+ - The frontend (either TCMU or Open-iSCSI/tgt are supported at this moment) is a kernel driver that translates read/write operations on the Longhorn block device (mapped at `/dev/longhorn/vol-name`) to user-level network requests on the controller.
+ - Each Longhorn block device is backed by its own dedicated controller.
+ - The controller sychronously replicates write operations to all replicas.
+ - The controller detects faulty replicas and rebuilds replicas.
+ - The controller coordinates snapshot and backup operations.
+ - Controllers and replicas are packaged as Docker containers.
 
 The following figure illustrates the relationship between the Longhorn block device, TCMU/tgt frontend, controller, and replicas.
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Longhorn Engine
 
 Longhorn Engine implements a lightweight block device storage controller capable of storing the data in a number of replicas. It functions like a network RAID controller.
 
-1. The replicas are backed by Linux sparse files, and support efficient snapshots using differencing disks.
-1. The replicas function like a networked disk, supporting read/write operations over a network protocol.
-1. The frontend (either TCMU or Open-iSCSI/tgt are supported at this moment) is a kernel driver that translates read/write operations on the Longhorn block device (mapped at `/dev/longhorn/vol-name`) to user-level network requests on the controller.
-1. Each Longhorn block device is backed by its own dedicated controller.
-1. The controller sychronously replicates write operations to all replicas.
-1. The controller detects faulty replicas and rebuilds replicas.
-1. The controller coordinates snapshot and backup operations.
-1. Controllers and replicas are packaged as Docker containers.
+-The replicas are backed by Linux sparse files, and support efficient snapshots using differencing disks.
+-The replicas function like a networked disk, supporting read/write operations over a network protocol.
+-The frontend (either TCMU or Open-iSCSI/tgt are supported at this moment) is a kernel driver that translates read/write operations on the Longhorn block device (mapped at `/dev/longhorn/vol-name`) to user-level network requests on the controller.
+-Each Longhorn block device is backed by its own dedicated controller.
+-The controller sychronously replicates write operations to all replicas.
+-The controller detects faulty replicas and rebuilds replicas.
+-The controller coordinates snapshot and backup operations.
+-Controllers and replicas are packaged as Docker containers.
 
 The following figure illustrates the relationship between the Longhorn block device, TCMU/tgt frontend, controller, and replicas.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following figure illustrates the relationship between the Longhorn block dev
 
 ## Building from source code
 
+Building from source code is as simple as using your terminal, and `cd`ing to the source directory, and running
 `make`
 
 


### PR DESCRIPTION
Rational:

For the first set of edits, a numbered list, in my opinion, doesn't make sense - it's not a list of operations or similar. A bulletpoint list is more appropriate here.

For the second edit, in the build section, It was a bit barren, and felt that it would be good to have more than just `make` - for example, telling the user to use their terminal. Yes, I know this is very basic, but sometimes even an experienced developer can have a bad day. More documentation never hurts.